### PR TITLE
fix: allow triggering of events after a stream has reached the end

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ Does not support native HTML5 MSE controls (`<video controls>`). It works, but e
 
 Does not support re-using the same video element.
 
-Does not support restarting the video after end of stream has been reached.
-
 ## Usage
 
 `npm install @eyevinn/media-event-filter`
@@ -315,6 +313,12 @@ Can not trigger before loaded.
 A timeupdate event
 
 Can not trigger before loaded.
+
+### ended
+
+The player has reached the end of a stream.
+
+To allow restarting the stream after the end of stream has been reached set `allowResumeAfterEnded` to `true`.
 
 ## Contributing
 


### PR DESCRIPTION
This PR fixes an issue where events wouldn't be emitted after the end state due to `isNotReady` being set to true even if the video element would trigger play/pause/seek etc. 