### PR TITLE
feat: prevent buffering at end of stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,30 +15,30 @@ Adheres to the [Eyevinn Player Analytics Specification](https://github.com/Eyevi
 ## Overview
 
 ```typescript
-  /** Loading of stream is complete, playback is ready to start */
-  /** It is now safe to let the user press a play button */
-  "loaded"
-  /** A seek has started */
-  "seeking"
-  /** A seek has ended  */
-  "seeked"
-  /** Buffering has started */
-  /** Does not trigger during seek, cancelled by a seek */
-   "buffering"
-  /** Buffering has ended */
-  /** Does not trigger during seek */
-  "buffered"
-  /** A request to start playing again has been made */
-  "play"
-  /** The stream has started playing after loading completed
-   *  OR the stream has started playing after the stream was previously paused */
-  "playing"
-  /** The stream has been paused */
-  "pause"
-  /** The end of the stream was reached */
-  "ended"
-  /** A timeupdate event */
-  "timeupdate"
+/** Loading of stream is complete, playback is ready to start */
+/** It is now safe to let the user press a play button */
+"loaded";
+/** A seek has started */
+"seeking";
+/** A seek has ended  */
+"seeked";
+/** Buffering has started */
+/** Does not trigger during seek, cancelled by a seek */
+"buffering";
+/** Buffering has ended */
+/** Does not trigger during seek */
+"buffered";
+/** A request to start playing again has been made */
+"play";
+/** The stream has started playing after loading completed
+ *  OR the stream has started playing after the stream was previously paused */
+"playing";
+/** The stream has been paused */
+"pause";
+/** The end of the stream was reached */
+"ended";
+/** A timeupdate event */
+"timeupdate";
 ```
 
 ## Limitations

--- a/src/media-event-filter.ts
+++ b/src/media-event-filter.ts
@@ -204,6 +204,8 @@ export const getMediaEventFilter = ({
   const onWaiting = (): void => {
     clearRatechangeBufferTimeout();
 
+    // Firefox + hls.js will cause a waiting event on reaching EOS
+    if (mediaElement.ended) return;
     // playback should be ready before reacting to "waiting" event
     if (isNotReady()) return;
     // ignore "waiting" while seeking
@@ -357,6 +359,9 @@ export const getMediaEventFilter = ({
 
   const onRatechange = (): void => {
     clearRatechangeBufferTimeout();
+
+    // Ignore ratechange if EOS has been reached
+    if (mediaElement.ended) return;
 
     const playbackRateIsPositive = mediaElement.playbackRate > 0;
 


### PR DESCRIPTION
Reaching EOS triggers a `waiting` event in some browsers, which will get translated to a buffering event right before ended propagates.

Discovered with Hls.js in Firefox. Shaka versions using playbackRate to buffer should not have the same issue.