### PR TITLE
feat!: remove allowResumeAfterEnded option

### DIFF
--- a/src/media-event-filter.ts
+++ b/src/media-event-filter.ts
@@ -27,7 +27,6 @@ type TFilteredMediaEventCallback = (event: FilteredMediaEvent) => void;
 type TMediaEventFilterOptions = {
   mediaElement: HTMLMediaElement;
   callback: TFilteredMediaEventCallback;
-  allowResumeAfterEnded?: boolean;
 };
 
 type TCallback = () => void;
@@ -102,7 +101,6 @@ export type TMediaEventFilter = {
 export const getMediaEventFilter = ({
   mediaElement,
   callback,
-  allowResumeAfterEnded = false,
 }: TMediaEventFilterOptions): TMediaEventFilter => {
   let ratechangeBufferTimeout: number | null = null;
 
@@ -124,8 +122,7 @@ export const getMediaEventFilter = ({
     };
   };
 
-  const isNotReady = (): boolean =>
-    allowResumeAfterEnded ? state.loading : state.loading || state.ended;
+  const isNotReady = (): boolean => state.loading || state.ended;
 
   // Reset state of media event filter when a new src is
   // attached to the media element.
@@ -172,12 +169,6 @@ export const getMediaEventFilter = ({
   const onSeeking = (): void => {
     // playback should be ready before reacting to "seeking" event (e.g. shaka jumps)
     if (isNotReady()) return;
-
-    // If stream has reached the end and an onSeeking has been triggered we want to set the ended state to false
-    // This can only happen if allowResumeAfterEnded is set to true (otherwise isNotReady is true)
-    if (state.ended) {
-      state.ended = false;
-    }
 
     // end ongoing buffering, this enables trackers to report
     // the buffer duration before starting the seek.


### PR DESCRIPTION
The filter now handles seeking back into video
after it has ended by default. The event flow
will be different from before, since we want
to treat reaching "ended" as a playback session
ending. Thus, seeking back into the video again
will trigger "loaded" as if a new session was
started.

BREAKING CHANGE:
allowResumeAfterEnded argument removed (this is now the default behaviour)