### PR TITLE
fix: prevent buggy buffer behaviour in Chrome

### DIFF
--- a/src/media-event-filter.ts
+++ b/src/media-event-filter.ts
@@ -449,7 +449,14 @@ export const getMediaEventFilter = ({
   const onTimeupdate = (): void => {
     if (isNotReady()) return;
 
-    if (state.buffering && !mediaElement.paused) {
+    if (
+      state.buffering &&
+      !mediaElement.paused &&
+      // Playhead changed while not paused and buffering is ongoing
+      // which could indicate resumed playback. Check readyState
+      // to confirm
+      mediaElement.readyState === 4
+    ) {
       state = {
         ...state,
         buffering: false,

--- a/src/media-event-filter.ts
+++ b/src/media-event-filter.ts
@@ -455,7 +455,9 @@ export const getMediaEventFilter = ({
       // Playhead changed while not paused and buffering is ongoing
       // which could indicate resumed playback. Check readyState
       // to confirm
-      mediaElement.readyState === HTMLMediaElement.HAVE_ENOUGH_DATA
+      mediaElement.readyState === HTMLMediaElement.HAVE_ENOUGH_DATA &&
+      // Ensure Shaka isn't performing internal buffering
+      mediaElement.playbackRate !== 0
     ) {
       state = {
         ...state,

--- a/src/media-event-filter.ts
+++ b/src/media-event-filter.ts
@@ -455,7 +455,7 @@ export const getMediaEventFilter = ({
       // Playhead changed while not paused and buffering is ongoing
       // which could indicate resumed playback. Check readyState
       // to confirm
-      mediaElement.readyState === 4
+      mediaElement.readyState === HTMLMediaElement.HAVE_ENOUGH_DATA
     ) {
       state = {
         ...state,


### PR DESCRIPTION
Check the media element's `readyState` to see if we should recover from buffering when `timeupdate` triggers.